### PR TITLE
Changed default of raise_for_status to match the docs

### DIFF
--- a/microflack_common/requests.py
+++ b/microflack_common/requests.py
@@ -32,7 +32,7 @@ def _get_requests_session():
 def _make_request(method, url, *args, **kwargs):
     if '://' not in url:
         url = os.environ['LB'] + url
-    raise_for_status = kwargs.pop('raise_for_status', True)
+    raise_for_status = kwargs.pop('raise_for_status', False)
 
     response = getattr(_get_requests_session(), method.lower())(
         url, *args, **kwargs)


### PR DESCRIPTION
According to the docstrings of the method types, the default should be False. If it's False it's much easier to check for response types. I based my code on this snippet and then spent a lot of time debugging my code before realizing that the docstrings weren't accurate.